### PR TITLE
fixing git config pre-commit.enable option and improving doc

### DIFF
--- a/docs/nixos-options.md
+++ b/docs/nixos-options.md
@@ -484,7 +484,7 @@ boolean
 
 
 
-Whether to enable git pre-commit hook\.
+Whether to enable git commit-msg hook\.
 
 
 

--- a/lib/modules/git.nix
+++ b/lib/modules/git.nix
@@ -137,7 +137,7 @@ in
 
     })
 
-    (lib.mkIf config.git.commit-msg.enable {
+    (lib.mkIf config.git.pre-commit.enable {
       rootDir."misc/git-hooks/pre-commit" =
         let
           indentString = str: numSpaces:


### PR DESCRIPTION
`git.pre-commit.enable` option was ignored before.
Improving doc msg for `git.commit-msg.enable`.