### PR TITLE
Fixing mold linking error

### DIFF
--- a/lib/mkTarget.nix
+++ b/lib/mkTarget.nix
@@ -72,7 +72,7 @@ else
             "${extraRustFlags}";
 
         nativeBuildInputs = lib.optionals (pkgs.stdenv.isLinux && canUseMold) [
-          pkgs.mold
+          pkgs.mold-wrapped
         ];
       }
       args;


### PR DESCRIPTION
I had some linking errors when trying to execute a compiled binary after updating to the latest version of flakebox. 

It looks like the new `mkTarget` doesn't use `mold-wrapped`, resulting in a compiled binary that doesn't know where to find dynamic libraries.