### PR TITLE
feat: adding pkgs support for cross-compilation

### DIFF
--- a/checks/workspace-cross-compile/default.nix
+++ b/checks/workspace-cross-compile/default.nix
@@ -22,8 +22,16 @@ let
     "scripts"
   ];
 
+  buildInputs = pkgs: [
+    pkgs.openssl
+  ];
+  
+  nativeBuildInputs = pkgs: [
+    pkgs.pkgsBuildTarget.pkg-config
+  ];
+
   multiOutput =
-    (flakeboxLib.craneMultiBuild { })
+    (flakeboxLib.craneMultiBuild { inherit buildInputs; inherit nativeBuildInputs; })
       (craneLib':
         let
           src = flakeboxLib.filterSubPaths {
@@ -35,14 +43,6 @@ let
             pname = "workspace-cross-compile";
             version = "0.0.1";
             inherit src;
-
-            buildInputs = [
-              pkgs.openssl
-            ];
-
-            nativeBuildInputs = [
-              pkgs.pkg-config
-            ];
           }).overrideArgsDepsOnly {
             cargoVendorDir = craneLib'.vendorCargoDeps {
               inherit src;
@@ -119,9 +119,13 @@ pkgs.linkFarmFromDrvs "workspace-non-rust" (
   ] ++
   lib.optionals (full && pkgs.stdenv.isLinux) [
     multiOutput.aarch64-linux.ci.workspaceBuild
+    multiOutput.aarch64-linux-musl.ci.workspaceBuild
     multiOutput.x86_64-linux.ci.workspaceBuild
+    multiOutput.x86_64-linux-musl.ci.workspaceBuild
     multiOutput.i686-linux.ci.workspaceBuild
+    multiOutput.i686-linux-musl.ci.workspaceBuild
     multiOutput.riscv64-linux.ci.workspaceBuild
+    multiOutput.mingw64.ci.workspaceBuild
   ] ++
     # in full mode, when supported, test all android targets
   lib.optionals (full && multiOutput ? aarch64-android) [

--- a/lib/craneMultiBuild.nix
+++ b/lib/craneMultiBuild.nix
@@ -1,25 +1,28 @@
-{
-  mkFenixToolchain,
-  craneLib,
-  mapWithToolchains,
-  mkTarget,
-  mkStdToolchains,
-  lib,
-}: let
+{ mkFenixToolchain
+, craneLib
+, mapWithToolchains
+, mkTarget
+, mkStdToolchains
+, lib
+,
+}:
+let
   craneLib' = craneLib;
 in
-  {
-    buildInputs ? pkgs: [],
-    nativeBuildInputs ? pkgs: [],
-    profiles ? ["dev" "ci" "release"],
-    craneLib ? craneLib',
-    toolchains ? null,
-  }: let
-    argToolchains = if toolchains != null then toolchains else (mkStdToolchains {inherit buildInputs nativeBuildInputs;});
-  in
-    outputsFn: let
-      profilesFn = craneLib: craneLib.mapWithProfiles outputsFn profiles;
-    in
-      (mapWithToolchains outputsFn {default = argToolchains.default;}).default
-      // (mapWithToolchains profilesFn {default = argToolchains.default;}).default
-      // (mapWithToolchains profilesFn argToolchains)
+{ buildInputs ? pkgs: [ ]
+, nativeBuildInputs ? pkgs: [ ]
+, profiles ? [ "dev" "ci" "release" ]
+, craneLib ? craneLib'
+, toolchains ? null
+,
+}:
+let
+  argToolchains = if toolchains != null then toolchains else (mkStdToolchains { inherit buildInputs nativeBuildInputs; });
+in
+outputsFn:
+let
+  profilesFn = craneLib: craneLib.mapWithProfiles outputsFn profiles;
+in
+(mapWithToolchains outputsFn { default = argToolchains.default; }).default
+// (mapWithToolchains profilesFn { default = argToolchains.default; }).default
+  // (mapWithToolchains profilesFn argToolchains)

--- a/lib/mkFenixToolchain.nix
+++ b/lib/mkFenixToolchain.nix
@@ -30,6 +30,7 @@ in
 , clang-unwrapped ? defaultClangUnwrapped
 , stdenv ? defaultStdenv
 , isLintShell ? false
+, craneArgs ? { }
 }:
 let
   mergeTargets = targetFn: prev:
@@ -71,7 +72,7 @@ let
     } else { };
 
   # this can't be a method on `craneLib` because it basically constructs the `craneLib`
-  craneLib = (enhanceCrane ((crane.mkLib pkgs).overrideToolchain toolchain)).overrideArgs ((mergeArgs commonArgs buildArgs) // { inherit stdenv; });
+  craneLib = (enhanceCrane ((crane.mkLib pkgs).overrideToolchain toolchain)).overrideArgs ((mergeArgs ((mergeArgs commonArgs buildArgs) // { inherit stdenv; }) craneArgs));
 in
 {
   inherit toolchain;

--- a/lib/mkStdTargets.nix
+++ b/lib/mkStdTargets.nix
@@ -137,6 +137,25 @@
       BINDGEN_EXTRA_CLANG_ARGS_riscv64gc_unknown_linux_gnu = "-I ${pkgs.pkgsCross.riscv64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
     };
   };
+
+  windows64 = mkClangTarget rec {
+    target = "x86_64-pc-windows-gnu";
+    clang = pkgs.pkgsCross.mingwW64.buildPackages.llvmPackages.clang;
+    binPrefix = "x86_64-w64-mingw32-";
+    llvmConfigPkg = targetLlvmConfigWrapper {
+      clangPkg = pkgs.pkgsCross.mingwW64.buildPackages.llvmPackages.clang-unwrapped;
+      libClangPkg = pkgs.pkgsCross.mingwW64.buildPackages.llvmPackages.clang-unwrapped.lib;
+    };
+
+    args = {
+      CFLAGS_x86_64_pc_windows_gnu = "-I ${pkgs.pkgsCross.mingwW64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      CPPFLAGS_x86_64_pc_windows_gnu = "-I ${pkgs.pkgsCross.mingwW64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      CXXFLAGS_x86_64_pc_windows_gnu = "-I ${pkgs.pkgsCross.mingwW64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      BINDGEN_EXTRA_CLANG_ARGS_x86_64_pc_windows_gnu = "-I ${pkgs.pkgsCross.mingwW64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      # compressed debug section support only when building on Linux
+      CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS = "-C link-arg=-fuse-ld=${clang}/bin/${binPrefix}ld -C link-arg=-Wl";
+    };
+  };
 } // {
   wasm32-unknown = { extraRustFlags, ... }@args: mkTarget
     {

--- a/lib/mkStdTargets.nix
+++ b/lib/mkStdTargets.nix
@@ -27,10 +27,10 @@
     };
 
     args = {
-      CFLAGS_aarch64_unknown_linux_gnu = "-I ${pkgs.pkgsCross.aarch64-multiplatform.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      CPPFLAGS_aarch64_unknown_linux_gnu = "-I ${pkgs.pkgsCross.aarch64-multiplatform.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      CXXFLAGS_aarch64_unknown_linux_gnu = "-I ${pkgs.pkgsCross.aarch64-multiplatform.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_gnu = "-I ${pkgs.pkgsCross.aarch64-multiplatform.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      CFLAGS_aarch64_unknown_linux_gnu = "-I ${pkgs.pkgsCross.aarch64-multiplatform.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      CPPFLAGS_aarch64_unknown_linux_gnu = "-I ${pkgs.pkgsCross.aarch64-multiplatform.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      CXXFLAGS_aarch64_unknown_linux_gnu = "-I ${pkgs.pkgsCross.aarch64-multiplatform.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_gnu = "-I ${pkgs.pkgsCross.aarch64-multiplatform.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
     };
   };
 
@@ -44,10 +44,10 @@
     };
 
     args = {
-      CFLAGS_aarch64_unknown_linux_musl = "-I ${pkgs.pkgsCross.aarch64-multiplatform-musl.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      CPPFLAGS_aarch64_unknown_linux_musl = "-I ${pkgs.pkgsCross.aarch64-multiplatform-musl.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      CXXFLAGS_aarch64_unknown_linux_musl = "-I ${pkgs.pkgsCross.aarch64-multiplatform-musl.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_musl = "-I ${pkgs.pkgsCross.aarch64-multiplatform-musl.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      CFLAGS_aarch64_unknown_linux_musl = "-I ${pkgs.pkgsCross.aarch64-multiplatform-musl.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      CPPFLAGS_aarch64_unknown_linux_musl = "-I ${pkgs.pkgsCross.aarch64-multiplatform-musl.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      CXXFLAGS_aarch64_unknown_linux_musl = "-I ${pkgs.pkgsCross.aarch64-multiplatform-musl.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_musl = "-I ${pkgs.pkgsCross.aarch64-multiplatform-musl.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
     };
   };
 
@@ -63,10 +63,10 @@
     };
 
     args = {
-      CFLAGS_x86_64_unknown_linux_gnu = "-I ${pkgs.pkgsCross.gnu64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      CPPFLAGS_x86_64_unknown_linux_gnu = "-I ${pkgs.pkgsCross.gnu64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      CXXFLAGS_x86_64_unknown_linux_gnu = "-I ${pkgs.pkgsCross.gnu64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_linux_gnu = "-I ${pkgs.pkgsCross.gnu64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      CFLAGS_x86_64_unknown_linux_gnu = "-I ${pkgs.pkgsCross.gnu64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      CPPFLAGS_x86_64_unknown_linux_gnu = "-I ${pkgs.pkgsCross.gnu64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      CXXFLAGS_x86_64_unknown_linux_gnu = "-I ${pkgs.pkgsCross.gnu64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_linux_gnu = "-I ${pkgs.pkgsCross.gnu64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
     };
   };
 
@@ -80,10 +80,10 @@
     };
 
     args = {
-      CFLAGS_x86_64_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      CPPFLAGS_x86_64_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      CXXFLAGS_x86_64_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      CFLAGS_x86_64_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      CPPFLAGS_x86_64_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      CXXFLAGS_x86_64_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
     };
   };
 
@@ -97,10 +97,10 @@
     };
 
     args = {
-      CFLAGS_i686_unknown_linux_gnu = "-I ${pkgs.pkgsCross.gnu32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      CPPFLAGS_i686_unknown_linux_gnu = "-I ${pkgs.pkgsCross.gnu32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      CXXFLAGS_i686_unknown_linux_gnu = "-I ${pkgs.pkgsCross.gnu32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      BINDGEN_EXTRA_CLANG_ARGS_i686_unknown_linux_gnu = "-I ${pkgs.pkgsCross.gnu32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      CFLAGS_i686_unknown_linux_gnu = "-I ${pkgs.pkgsCross.gnu32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      CPPFLAGS_i686_unknown_linux_gnu = "-I ${pkgs.pkgsCross.gnu32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      CXXFLAGS_i686_unknown_linux_gnu = "-I ${pkgs.pkgsCross.gnu32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      BINDGEN_EXTRA_CLANG_ARGS_i686_unknown_linux_gnu = "-I ${pkgs.pkgsCross.gnu32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
     };
   };
 
@@ -114,10 +114,10 @@
     };
 
     args = {
-      CFLAGS_i686_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      CPPFLAGS_i686_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      CXXFLAGS_i686_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      BINDGEN_EXTRA_CLANG_ARGS_i686_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      CFLAGS_i686_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      CPPFLAGS_i686_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      CXXFLAGS_i686_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      BINDGEN_EXTRA_CLANG_ARGS_i686_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
     };
   };
 
@@ -131,10 +131,10 @@
     };
 
     args = {
-      CFLAGS_riscv64gc_unknown_linux_gnu = "-I ${pkgs.pkgsCross.riscv64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      CPPFLAGS_riscv64gc_unknown_linux_gnu = "-I ${pkgs.pkgsCross.riscv64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      CXXFLAGS_riscv64gc_unknown_linux_gnu = "-I ${pkgs.pkgsCross.riscv64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      BINDGEN_EXTRA_CLANG_ARGS_riscv64gc_unknown_linux_gnu = "-I ${pkgs.pkgsCross.riscv64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      CFLAGS_riscv64gc_unknown_linux_gnu = "-I ${pkgs.pkgsCross.riscv64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      CPPFLAGS_riscv64gc_unknown_linux_gnu = "-I ${pkgs.pkgsCross.riscv64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      CXXFLAGS_riscv64gc_unknown_linux_gnu = "-I ${pkgs.pkgsCross.riscv64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      BINDGEN_EXTRA_CLANG_ARGS_riscv64gc_unknown_linux_gnu = "-I ${pkgs.pkgsCross.riscv64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
     };
   };
 
@@ -148,10 +148,10 @@
     };
 
     args = {
-      CFLAGS_x86_64_pc_windows_gnu = "-I ${pkgs.pkgsCross.mingwW64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      CPPFLAGS_x86_64_pc_windows_gnu = "-I ${pkgs.pkgsCross.mingwW64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      CXXFLAGS_x86_64_pc_windows_gnu = "-I ${pkgs.pkgsCross.mingwW64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      BINDGEN_EXTRA_CLANG_ARGS_x86_64_pc_windows_gnu = "-I ${pkgs.pkgsCross.mingwW64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      CFLAGS_x86_64_pc_windows_gnu = "-I ${pkgs.pkgsCross.mingwW64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      CPPFLAGS_x86_64_pc_windows_gnu = "-I ${pkgs.pkgsCross.mingwW64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      CXXFLAGS_x86_64_pc_windows_gnu = "-I ${pkgs.pkgsCross.mingwW64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      BINDGEN_EXTRA_CLANG_ARGS_x86_64_pc_windows_gnu = "-I ${pkgs.pkgsCross.mingwW64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
       # compressed debug section support only when building on Linux
       CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS = "-C link-arg=-fuse-ld=${clang}/bin/${binPrefix}ld -C link-arg=-Wl";
     };
@@ -219,10 +219,10 @@
     };
 
     args = {
-      CFLAGS_aarch64_unknown_darwin_gnu = "-I ${pkgs.pkgsCross.aarch64-darwin.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      CPPFLAGS_aarch64_unknown_darwin_gnu = "-I ${pkgs.pkgsCross.aarch64-darwin.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      CXXFLAGS_aarch64_unknown_darwin_gnu = "-I ${pkgs.pkgsCross.aarch64-darwin.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_darwin_gnu = "-I ${pkgs.pkgsCross.aarch64-darwin.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      CFLAGS_aarch64_unknown_darwin_gnu = "-I ${pkgs.pkgsCross.aarch64-darwin.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      CPPFLAGS_aarch64_unknown_darwin_gnu = "-I ${pkgs.pkgsCross.aarch64-darwin.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      CXXFLAGS_aarch64_unknown_darwin_gnu = "-I ${pkgs.pkgsCross.aarch64-darwin.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_darwin_gnu = "-I ${pkgs.pkgsCross.aarch64-darwin.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
     };
   };
 
@@ -237,10 +237,10 @@
     };
 
     args = {
-      CFLAGS_x86_64_unknown_darwin_gnu = "-I ${pkgs.pkgsCross.x86_64-darwin.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      CPPFLAGS_x86_64_unknown_darwin_gnu = "-I ${pkgs.pkgsCross.x86_64-darwin.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      CXXFLAGS_x86_64_unknown_darwin_gnu = "-I ${pkgs.pkgsCross.x86_64-darwin.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
-      BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_darwin_gnu = "-I ${pkgs.pkgsCross.x86_64-darwin.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      CFLAGS_x86_64_unknown_darwin_gnu = "-I ${pkgs.pkgsCross.x86_64-darwin.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      CPPFLAGS_x86_64_unknown_darwin_gnu = "-I ${pkgs.pkgsCross.x86_64-darwin.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      CXXFLAGS_x86_64_unknown_darwin_gnu = "-I ${pkgs.pkgsCross.x86_64-darwin.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
+      BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_darwin_gnu = "-I ${pkgs.pkgsCross.x86_64-darwin.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/17/include/";
     };
   };
 } // lib.optionalAttrs (pkgs.stdenv.isDarwin) {

--- a/lib/mkStdTargets.nix
+++ b/lib/mkStdTargets.nix
@@ -34,6 +34,23 @@
     };
   };
 
+  aarch64-linux-musl = mkClangTarget {
+    target = "aarch64-unknown-linux-musl";
+    clang = pkgs.pkgsCross.aarch64-multiplatform-musl.buildPackages.llvmPackages.clang;
+    binPrefix = "aarch64-unknown-linux-musl-";
+    llvmConfigPkg = targetLlvmConfigWrapper {
+      clangPkg = pkgs.pkgsCross.aarch64-multiplatform-musl.buildPackages.llvmPackages.clang-unwrapped;
+      libClangPkg = pkgs.pkgsCross.aarch64-multiplatform-musl.buildPackages.llvmPackages.clang-unwrapped.lib;
+    };
+
+    args = {
+      CFLAGS_aarch64_unknown_linux_musl = "-I ${pkgs.pkgsCross.aarch64-multiplatform-musl.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      CPPFLAGS_aarch64_unknown_linux_musl = "-I ${pkgs.pkgsCross.aarch64-multiplatform-musl.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      CXXFLAGS_aarch64_unknown_linux_musl = "-I ${pkgs.pkgsCross.aarch64-multiplatform-musl.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      BINDGEN_EXTRA_CLANG_ARGS_aarch64_unknown_linux_musl = "-I ${pkgs.pkgsCross.aarch64-multiplatform-musl.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+    };
+  };
+
   x86_64-linux = mkClangTarget {
     target = "x86_64-unknown-linux-gnu";
     clang = pkgs.pkgsCross.gnu64.buildPackages.llvmPackages.clang;
@@ -53,6 +70,23 @@
     };
   };
 
+  x86_64-linux-musl = mkClangTarget {
+    target = "x86_64-unknown-linux-musl";
+    clang = pkgs.pkgsCross.musl64.buildPackages.llvmPackages.clang;
+    binPrefix = "x86_64-unknown-linux-musl-";
+    llvmConfigPkg = targetLlvmConfigWrapper {
+      clangPkg = pkgs.pkgsCross.musl64.buildPackages.llvmPackages.clang-unwrapped;
+      libClangPkg = pkgs.pkgsCross.musl64.buildPackages.llvmPackages.clang-unwrapped.lib;
+    };
+
+    args = {
+      CFLAGS_x86_64_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      CPPFLAGS_x86_64_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      CXXFLAGS_x86_64_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      BINDGEN_EXTRA_CLANG_ARGS_x86_64_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl64.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+    };
+  };
+
   i686-linux = mkClangTarget {
     target = "i686-unknown-linux-gnu";
     clang = pkgs.pkgsCross.gnu32.buildPackages.llvmPackages.clang;
@@ -67,6 +101,23 @@
       CPPFLAGS_i686_unknown_linux_gnu = "-I ${pkgs.pkgsCross.gnu32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
       CXXFLAGS_i686_unknown_linux_gnu = "-I ${pkgs.pkgsCross.gnu32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
       BINDGEN_EXTRA_CLANG_ARGS_i686_unknown_linux_gnu = "-I ${pkgs.pkgsCross.gnu32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+    };
+  };
+
+  i686-linux-musl = mkClangTarget {
+    target = "i686-unknown-linux-musl";
+    clang = pkgs.pkgsCross.musl32.buildPackages.llvmPackages.clang;
+    binPrefix = "i686-unknown-linux-musl-";
+    llvmConfigPkg = targetLlvmConfigWrapper {
+      clangPkg = pkgs.pkgsCross.musl32.buildPackages.llvmPackages.clang-unwrapped;
+      libClangPkg = pkgs.pkgsCross.musl32.buildPackages.llvmPackages.clang-unwrapped.lib;
+    };
+
+    args = {
+      CFLAGS_i686_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      CPPFLAGS_i686_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      CXXFLAGS_i686_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
+      BINDGEN_EXTRA_CLANG_ARGS_i686_unknown_linux_musl = "-I ${pkgs.pkgsCross.musl32.buildPackages.llvmPackages.clang-unwrapped.lib}/lib/clang/16/include/";
     };
   };
 

--- a/lib/mkStdTargets.nix
+++ b/lib/mkStdTargets.nix
@@ -138,7 +138,7 @@
     };
   };
 
-  windows64 = mkClangTarget rec {
+  mingw64 = mkClangTarget rec {
     target = "x86_64-pc-windows-gnu";
     clang = pkgs.pkgsCross.mingwW64.buildPackages.llvmPackages.clang;
     binPrefix = "x86_64-w64-mingw32-";

--- a/lib/mkStdToolchains.nix
+++ b/lib/mkStdToolchains.nix
@@ -115,6 +115,20 @@ in
         nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.riscv64;
     };
   });
+  windows64 = mkFenixToolchain (args // {
+    defaultTarget = "x86_64-pc-windows-gnu";
+    targets = {
+      windows64 = stdTargets.windows64;
+    };
+    craneArgs = {
+        buildInputs = buildInputs pkgs.pkgsCross.mingwW64;
+        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.mingwW64;
+        depsBuildBuild = [
+            pkgs.pkgsCross.mingwW64.stdenv.cc
+            pkgs.pkgsCross.mingwW64.windows.pthreads
+        ];
+    };
+  });
 } // {
 
   wasm32-unknown = mkFenixToolchain (args // {

--- a/lib/mkStdToolchains.nix
+++ b/lib/mkStdToolchains.nix
@@ -149,9 +149,12 @@ in
     targets = {
       aarch64-android = stdTargets.aarch64-android;
     };
+    # FIXME: crossPkgs for aarch64-android-prebuilt are broken for certain packages (e.g. openssl)
+    # https://github.com/NixOS/nixpkgs/issues/319863
+    # we use native pkgs as a fallback
     craneArgs = {
-      buildInputs = buildInputs pkgs.pkgsCross.aarch64-android-prebuilt;
-      nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.aarch64-android-prebuilt;
+      buildInputs = buildInputs pkgs;
+      nativeBuildInputs = nativeBuildInputs pkgs;
     };
   };
   x86_64-android = mkFenixToolchain {
@@ -159,25 +162,35 @@ in
     targets = {
       x86_64-android = stdTargets.x86_64-android;
     };
-    # no crossPkgs available
-    craneArgs = { };
+    # FIXME: no crossPkgs available
+    # we use native pkgs as a fallback
+    craneArgs = {
+      buildInputs = buildInputs pkgs;
+      nativeBuildInputs = nativeBuildInputs pkgs;
+    };
   };
   i686-android = mkFenixToolchain {
     defaultTarget = "i686-linux-android";
     targets = {
       i686-android = stdTargets.i686-android;
     };
-    # no crossPkgs available
-    craneArgs = { };
+    # FIXME: no crossPkgs available, use native pkgs as a fallback
+    craneArgs = {
+      buildInputs = buildInputs pkgs;
+      nativeBuildInputs = nativeBuildInputs pkgs;
+    };
   };
   armv7-android = mkFenixToolchain {
     defaultTarget = "armv7-linux-androideabi";
     targets = {
       armv7-android = stdTargets.armv7-android;
     };
+    # FIXME: crossPkgs for armv7a-android-prebuilt are broken for certain packages (e.g. openssl)
+    # https://github.com/NixOS/nixpkgs/issues/319863
+    # we use native pkgs as a fallback
     craneArgs = {
-      buildInputs = buildInputs pkgs.pkgsCross.armv7-android-prebuilt;
-      nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.armv7-android-prebuilt;
+      buildInputs = buildInputs pkgs;
+      nativeBuildInputs = nativeBuildInputs pkgs;
     };
   };
 

--- a/lib/mkStdToolchains.nix
+++ b/lib/mkStdToolchains.nix
@@ -14,13 +14,13 @@
 , libclang ? defaultLibClang
 , clang-unwrapped ? defaultClangUnwrapped
 , stdenv ? defaultStdenv
-, buildInputs ? pkgs: []
-, nativeBuildInputs ? pkgs: []
+, buildInputs ? pkgs: [ ]
+, nativeBuildInputs ? pkgs: [ ]
 , ...
 }@oldArgs:
 let
-stdTargets = mkStdTargets { };
-args = removeAttrs oldArgs [ "buildInputs" "nativeBuildInputs" ];
+  stdTargets = mkStdTargets { };
+  args = removeAttrs oldArgs [ "buildInputs" "nativeBuildInputs" ];
 in
 {
   default = mkFenixToolchain (args // {
@@ -28,8 +28,8 @@ in
       default = stdTargets.default;
     };
     craneArgs = {
-        buildInputs = buildInputs pkgs;
-        nativeBuildInputs = nativeBuildInputs pkgs;
+      buildInputs = buildInputs pkgs;
+      nativeBuildInputs = nativeBuildInputs pkgs;
     };
   });
 
@@ -39,8 +39,8 @@ in
     };
     channel = "complete";
     craneArgs = {
-        buildInputs = buildInputs pkgs;
-        nativeBuildInputs = nativeBuildInputs pkgs;
+      buildInputs = buildInputs pkgs;
+      nativeBuildInputs = nativeBuildInputs pkgs;
     };
   });
 
@@ -51,8 +51,8 @@ in
       default = stdTargets.aarch64-linux;
     };
     craneArgs = {
-        buildInputs = buildInputs pkgs.pkgsCross.aarch64-multiplatform;
-        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.aarch64-multiplatform;
+      buildInputs = buildInputs pkgs.pkgsCross.aarch64-multiplatform;
+      nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.aarch64-multiplatform;
     };
   });
   aarch64-linux-musl = mkFenixToolchain (args // {
@@ -61,8 +61,8 @@ in
       default = stdTargets.aarch64-linux-musl;
     };
     craneArgs = {
-        buildInputs = buildInputs pkgs.pkgsCross.aarch64-multiplatform-musl;
-        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.aarch64-multiplatform-musl;
+      buildInputs = buildInputs pkgs.pkgsCross.aarch64-multiplatform-musl;
+      nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.aarch64-multiplatform-musl;
     };
   });
   x86_64-linux = mkFenixToolchain (args // {
@@ -71,8 +71,8 @@ in
       x86_64-linux = stdTargets.x86_64-linux;
     };
     craneArgs = {
-        buildInputs = buildInputs pkgs.pkgsCross.gnu64;
-        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.gnu64;
+      buildInputs = buildInputs pkgs.pkgsCross.gnu64;
+      nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.gnu64;
     };
   });
   x86_64-linux-musl = mkFenixToolchain (args // {
@@ -81,8 +81,8 @@ in
       x86_64-linux-musl = stdTargets.x86_64-linux-musl;
     };
     craneArgs = {
-        buildInputs = buildInputs pkgs.pkgsCross.musl64;
-        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.musl64;
+      buildInputs = buildInputs pkgs.pkgsCross.musl64;
+      nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.musl64;
     };
   });
   i686-linux = mkFenixToolchain (args // {
@@ -91,8 +91,8 @@ in
       i686-linux = stdTargets.i686-linux;
     };
     craneArgs = {
-        buildInputs = buildInputs pkgs.pkgsCross.gnu32;
-        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.gnu32;
+      buildInputs = buildInputs pkgs.pkgsCross.gnu32;
+      nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.gnu32;
     };
   });
   i686-linux-musl = mkFenixToolchain (args // {
@@ -101,8 +101,8 @@ in
       i686-linux = stdTargets.i686-linux-musl;
     };
     craneArgs = {
-        buildInputs = buildInputs pkgs.pkgsCross.musl32;
-        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.musl32;
+      buildInputs = buildInputs pkgs.pkgsCross.musl32;
+      nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.musl32;
     };
   });
   riscv64-linux = mkFenixToolchain (args // {
@@ -111,22 +111,22 @@ in
       riscv64-linux = stdTargets.riscv64-linux;
     };
     craneArgs = {
-        buildInputs = buildInputs pkgs.pkgsCross.riscv64;
-        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.riscv64;
+      buildInputs = buildInputs pkgs.pkgsCross.riscv64;
+      nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.riscv64;
     };
   });
-  windows64 = mkFenixToolchain (args // {
+  mingw64 = mkFenixToolchain (args // {
     defaultTarget = "x86_64-pc-windows-gnu";
     targets = {
-      windows64 = stdTargets.windows64;
+      mingw64 = stdTargets.mingw64;
     };
     craneArgs = {
-        buildInputs = buildInputs pkgs.pkgsCross.mingwW64;
-        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.mingwW64;
-        depsBuildBuild = [
-            pkgs.pkgsCross.mingwW64.stdenv.cc
-            pkgs.pkgsCross.mingwW64.windows.pthreads
-        ];
+      buildInputs = buildInputs pkgs.pkgsCross.mingwW64;
+      nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.mingwW64;
+      depsBuildBuild = [
+        pkgs.pkgsCross.mingwW64.stdenv.cc
+        pkgs.pkgsCross.mingwW64.windows.pthreads
+      ];
     };
   });
 } // {
@@ -137,8 +137,8 @@ in
       wasm32-unknown = stdTargets.wasm32-unknown;
     };
     craneArgs = {
-        buildInputs = buildInputs pkgs.pkgsCross.wasi32;
-        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.wasi32;
+      buildInputs = buildInputs pkgs.pkgsCross.wasi32;
+      nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.wasi32;
     };
   });
 
@@ -150,8 +150,8 @@ in
       aarch64-android = stdTargets.aarch64-android;
     };
     craneArgs = {
-        buildInputs = buildInputs pkgs.pkgsCross.aarch64-android-prebuilt;
-        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.aarch64-android-prebuilt;
+      buildInputs = buildInputs pkgs.pkgsCross.aarch64-android-prebuilt;
+      nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.aarch64-android-prebuilt;
     };
   };
   x86_64-android = mkFenixToolchain {
@@ -160,7 +160,7 @@ in
       x86_64-android = stdTargets.x86_64-android;
     };
     # no crossPkgs available
-    craneArgs = {};
+    craneArgs = { };
   };
   i686-android = mkFenixToolchain {
     defaultTarget = "i686-linux-android";
@@ -168,7 +168,7 @@ in
       i686-android = stdTargets.i686-android;
     };
     # no crossPkgs available
-    craneArgs = {};
+    craneArgs = { };
   };
   armv7-android = mkFenixToolchain {
     defaultTarget = "armv7-linux-androideabi";
@@ -176,8 +176,8 @@ in
       armv7-android = stdTargets.armv7-android;
     };
     craneArgs = {
-        buildInputs = buildInputs pkgs.pkgsCross.armv7-android-prebuilt;
-        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.armv7-android-prebuilt;
+      buildInputs = buildInputs pkgs.pkgsCross.armv7-android-prebuilt;
+      nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.armv7-android-prebuilt;
     };
   };
 
@@ -188,8 +188,8 @@ in
       aarch64-darwin = stdTargets.aarch64-darwin;
     };
     craneArgs = {
-        buildInputs = buildInputs pkgs.pkgsCross.aarch64-darwin;
-        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.aarch64-darwin;
+      buildInputs = buildInputs pkgs.pkgsCross.aarch64-darwin;
+      nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.aarch64-darwin;
     };
   });
 
@@ -200,8 +200,8 @@ in
       x86_64-darwin = stdTargets.x86_64-darwin;
     };
     craneArgs = {
-        buildInputs = buildInputs pkgs.pkgsCross.x86_64-darwin;
-        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.x86_64-darwin;
+      buildInputs = buildInputs pkgs.pkgsCross.x86_64-darwin;
+      nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.x86_64-darwin;
     };
   });
 }

--- a/lib/mkStdToolchains.nix
+++ b/lib/mkStdToolchains.nix
@@ -14,15 +14,22 @@
 , libclang ? defaultLibClang
 , clang-unwrapped ? defaultClangUnwrapped
 , stdenv ? defaultStdenv
+, buildInputs ? pkgs: []
+, nativeBuildInputs ? pkgs: []
 , ...
-}@args:
+}@oldArgs:
 let
-  stdTargets = mkStdTargets { };
+stdTargets = mkStdTargets { };
+args = removeAttrs oldArgs [ "buildInputs" "nativeBuildInputs" ];
 in
 {
   default = mkFenixToolchain (args // {
     targets = {
       default = stdTargets.default;
+    };
+    craneArgs = {
+        buildInputs = buildInputs pkgs;
+        nativeBuildInputs = nativeBuildInputs pkgs;
     };
   });
 
@@ -31,6 +38,10 @@ in
       default = stdTargets.default;
     };
     channel = "complete";
+    craneArgs = {
+        buildInputs = buildInputs pkgs;
+        nativeBuildInputs = nativeBuildInputs pkgs;
+    };
   });
 
 } // lib.optionalAttrs pkgs.stdenv.isLinux {
@@ -39,11 +50,19 @@ in
     targets = {
       default = stdTargets.aarch64-linux;
     };
+    craneArgs = {
+        buildInputs = buildInputs pkgs.pkgsCross.aarch64-multiplatform;
+        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.aarch64-multiplatform;
+    };
   });
   x86_64-linux = mkFenixToolchain (args // {
     defaultTarget = "x86_64-unknown-linux-gnu";
     targets = {
       x86_64-linux = stdTargets.x86_64-linux;
+    };
+    craneArgs = {
+        buildInputs = buildInputs pkgs.pkgsCross.gnu64;
+        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.gnu64;
     };
   });
   i686-linux = mkFenixToolchain (args // {
@@ -51,11 +70,19 @@ in
     targets = {
       i686-linux = stdTargets.i686-linux;
     };
+    craneArgs = {
+        buildInputs = buildInputs pkgs.pkgsCross.gnu32;
+        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.gnu32;
+    };
   });
   riscv64-linux = mkFenixToolchain (args // {
     defaultTarget = "riscv64gc-unknown-linux-gnu";
     targets = {
       riscv64-linux = stdTargets.riscv64-linux;
+    };
+    craneArgs = {
+        buildInputs = buildInputs pkgs.pkgsCross.riscv64;
+        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.riscv64;
     };
   });
 } // {
@@ -64,6 +91,10 @@ in
     defaultTarget = "wasm32-unknown-unknown";
     targets = {
       wasm32-unknown = stdTargets.wasm32-unknown;
+    };
+    craneArgs = {
+        buildInputs = buildInputs pkgs.pkgsCross.wasi32;
+        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.wasi32;
     };
   });
 
@@ -74,23 +105,35 @@ in
     targets = {
       aarch64-android = stdTargets.aarch64-android;
     };
+    craneArgs = {
+        buildInputs = buildInputs pkgs.pkgsCross.aarch64-android-prebuilt;
+        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.aarch64-android-prebuilt;
+    };
   };
   x86_64-android = mkFenixToolchain {
     defaultTarget = "x86_64-linux-android";
     targets = {
       x86_64-android = stdTargets.x86_64-android;
     };
+    # no crossPkgs available
+    craneArgs = {};
   };
   i686-android = mkFenixToolchain {
     defaultTarget = "i686-linux-android";
     targets = {
       i686-android = stdTargets.i686-android;
     };
+    # no crossPkgs available
+    craneArgs = {};
   };
   armv7-android = mkFenixToolchain {
     defaultTarget = "armv7-linux-androideabi";
     targets = {
       armv7-android = stdTargets.armv7-android;
+    };
+    craneArgs = {
+        buildInputs = buildInputs pkgs.pkgsCross.armv7-android-prebuilt;
+        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.armv7-android-prebuilt;
     };
   };
 
@@ -100,6 +143,8 @@ in
     targets = {
       aarch64-darwin = stdTargets.aarch64-darwin;
     };
+    # cross compilation is broken for apple-darwin
+    craneArgs = {};
   });
 
 } // lib.optionalAttrs (pkgs.stdenv.buildPlatform.config == "x86_64-apple-darwin") {
@@ -108,5 +153,7 @@ in
     targets = {
       x86_64-darwin = stdTargets.x86_64-darwin;
     };
+    # cross compilation is broken for apple-darwin
+    craneArgs = {};
   });
 }

--- a/lib/mkStdToolchains.nix
+++ b/lib/mkStdToolchains.nix
@@ -55,6 +55,16 @@ in
         nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.aarch64-multiplatform;
     };
   });
+  aarch64-linux-musl = mkFenixToolchain (args // {
+    defaultTarget = "aarch64-unknown-linux-musl";
+    targets = {
+      default = stdTargets.aarch64-linux-musl;
+    };
+    craneArgs = {
+        buildInputs = buildInputs pkgs.pkgsCross.aarch64-multiplatform-musl;
+        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.aarch64-multiplatform-musl;
+    };
+  });
   x86_64-linux = mkFenixToolchain (args // {
     defaultTarget = "x86_64-unknown-linux-gnu";
     targets = {
@@ -65,6 +75,16 @@ in
         nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.gnu64;
     };
   });
+  x86_64-linux-musl = mkFenixToolchain (args // {
+    defaultTarget = "x86_64-unknown-linux-musl";
+    targets = {
+      x86_64-linux-musl = stdTargets.x86_64-linux-musl;
+    };
+    craneArgs = {
+        buildInputs = buildInputs pkgs.pkgsCross.musl64;
+        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.musl64;
+    };
+  });
   i686-linux = mkFenixToolchain (args // {
     defaultTarget = "i686-unknown-linux-gnu";
     targets = {
@@ -73,6 +93,16 @@ in
     craneArgs = {
         buildInputs = buildInputs pkgs.pkgsCross.gnu32;
         nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.gnu32;
+    };
+  });
+  i686-linux-musl = mkFenixToolchain (args // {
+    defaultTarget = "i686-unknown-linux-musl";
+    targets = {
+      i686-linux = stdTargets.i686-linux-musl;
+    };
+    craneArgs = {
+        buildInputs = buildInputs pkgs.pkgsCross.musl32;
+        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.musl32;
     };
   });
   riscv64-linux = mkFenixToolchain (args // {

--- a/lib/mkStdToolchains.nix
+++ b/lib/mkStdToolchains.nix
@@ -187,8 +187,10 @@ in
     targets = {
       aarch64-darwin = stdTargets.aarch64-darwin;
     };
-    # cross compilation is broken for apple-darwin
-    craneArgs = {};
+    craneArgs = {
+        buildInputs = buildInputs pkgs.pkgsCross.aarch64-darwin;
+        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.aarch64-darwin;
+    };
   });
 
 } // lib.optionalAttrs (pkgs.stdenv.buildPlatform.config == "x86_64-apple-darwin") {
@@ -197,7 +199,9 @@ in
     targets = {
       x86_64-darwin = stdTargets.x86_64-darwin;
     };
-    # cross compilation is broken for apple-darwin
-    craneArgs = {};
+    craneArgs = {
+        buildInputs = buildInputs pkgs.pkgsCross.x86_64-darwin;
+        nativeBuildInputs = nativeBuildInputs pkgs.pkgsCross.x86_64-darwin;
+    };
   });
 }


### PR DESCRIPTION
closes #160.

This should not introduce any breaking changes, we can now pass a `buildInputs` and `nativeBuildInputs` lambda to `craneMultiBuild` that we get resolved in `mkStdToolchains` and ultimately passed to `craneLib` in `mkFenixToolchain`.

EDIT: I just realized my new commits were also forwarded to this PR, they basically add new targets (linux musl variants + windows64 with mingw).