### PR TITLE
fix(docs): fixes nix build .#docs

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -41,7 +41,8 @@ let
 
   optionsDocMd =
     pkgs.runCommand "options-doc.md" { } ''
-      cat ${optionsDoc.optionsCommonMark} >> $out
+      mkdir $out -p
+      cat ${optionsDoc.optionsCommonMark} >> $out/options-doc.md
     '';
 in
 lib.makeScope pkgs.newScope (self:
@@ -72,7 +73,7 @@ in
       # symlink our generated docs into the correct folder before generating
       buildPhase = ''
         rm -f ./nixos-options.md
-        ln -s ${optionsDocMd} "./nixos-options.md"
+        ln -s ${optionsDocMd}/options-doc.md "./nixos-options.md"
         # generate the site
         mdbook build
       '';


### PR DESCRIPTION
# The Problem
Currently `nix build github:rustshop/flakebox#docs` and therefore also `flakebox docs` fails.
With this change the build succeeds `nix build github:taliyahwebb/flakebox/docs-fix#docs`

## Basic Analysis
In my testing i figured out that the stdenv default builder tries to execute the output of the internal `optionsDocMd` derivation which is added to the docs `buildInputs`.

From as far as I can tell this only happens when a derivation is created from `pkgs.runCommand` and writes directly to `$out` instead of creating a directory and putting a file in that.

## Details
I was able to find out that during`source $stdenv/setup` any derivation output that is formed like described above is attempted to be executed by what i assume to be `bash`.
I was unable to investigate a further cause and didn't find any documentation or mention of this behavior so this might be a `nixpkgs.stdenv` bug?

## Alternative Fix
An alternative fix for the build failure that I attempted was to simply remove `optionsDocMd` from `buildInputs` but keep it during build phase, which seemed to work initially.
I am not familiar enough with nix yet to know if that would cause any unwanted side effects and thus decided to make a fixing change to the `optionsDocMd`  derivation instead.