### PR TITLE
chore: update deprecated hash value key

### DIFF
--- a/lib/flakeboxBin.nix
+++ b/lib/flakeboxBin.nix
@@ -20,5 +20,5 @@ pkgs.rustPlatform.buildRustPackage {
   pname = "flakebox";
   version = "0.1.0";
 
-  cargoSha256 = "sha256-hsHGZAxZube9xpdVp4xxZu6c+9s0mLO1GpZlPIwJ348=";
+  cargoHash = "sha256-hsHGZAxZube9xpdVp4xxZu6c+9s0mLO1GpZlPIwJ348=";
 }


### PR DESCRIPTION
change made in response to
`evaluation warning: cargoSha256 is deprecated. Please use cargoHash with SRI hash instead`
during build of flakeboxBin