### PR TITLE
fix: remove unneeded nixpkgs input to crane

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,6 @@
 
     crane = {
       url = "github:ipetkov/crane/?rev=19de14aaeb869287647d9461cbd389187d8ecdb7";
-      inputs.nixpkgs.follows = "nixpkgs";
     };
 
     fenix = {


### PR DESCRIPTION
When I first ran `nix develop` I saw a the error below:

> warning: input 'crane' has an override for a non-existent input
'nixpkgs'

This commit makes it go away. Doesn't seem like crane's flake has any inputs: https://github.com/ipetkov/crane/blob/70947c1908108c0c551ddfd73d4f750ff2ea67cd/flake.nix#L4