### PR TITLE
fix: remove errant backtick which broke link

### DIFF
--- a/docs/android-toolchains.md
+++ b/docs/android-toolchains.md
@@ -1,6 +1,6 @@
 # Android toolchains
 
-Android toolchains uses [`android-nixpkgs`](https://github.com/tadfisher/android-nixpkgs`) to
+Android toolchains uses [`android-nixpkgs`](https://github.com/tadfisher/android-nixpkgs) to
 source precompiled Android toolchains.
 
 Toolchain short-names:


### PR DESCRIPTION
On master, clicking the link sends you to https://github.com/tadfisher/android-nixpkgs%60