### PR TITLE
fix: fix defaultStdenv on MacOS

### DIFF
--- a/lib/default.nix
+++ b/lib/default.nix
@@ -140,7 +140,7 @@ lib.makeScope pkgs.newScope (
         pkgs.llvmPackages.clang-unwrapped
       else
         pkgs.llvmPackages_18.clang-unwrapped;
-    defaultStdenv = if pkgs.stdenv.isDarwin then pkgs.clang18Stdenv else pkgs.stdenv;
+    defaultStdenv = if pkgs.stdenv.isDarwin then pkgs.llvmPackages_18.stdenv else pkgs.stdenv;
 
     mkTarget = callPackage ./mkTarget.nix { };
     mkAndroidTarget = callPackage ./mkAndroidTarget.nix { };


### PR DESCRIPTION
pkgs.clang18Stdenv doesn't exist, pkgs.llvmPackages_18.stdenv does.

I ran into this in this tutorial while running `nix develop` for the first time:
https://github.com/rustshop/flakebox/blob/master/docs/building-new-project.md.

Applying this change to a local checkout of flakebox fixed the problem for me. At least it allowed me to run `nix develop`.