### PR TITLE
fix: set `useFetchCargoVendor = true;` in lib/flakeboxBin.nix

### DIFF
--- a/lib/flakeboxBin.nix
+++ b/lib/flakeboxBin.nix
@@ -20,5 +20,6 @@ pkgs.rustPlatform.buildRustPackage {
   pname = "flakebox";
   version = "0.1.0";
 
-  cargoHash = "sha256-hsHGZAxZube9xpdVp4xxZu6c+9s0mLO1GpZlPIwJ348=";
+  cargoHash = "sha256-L0UAVv+JUuADoMH2RiYUCnyOKNMBVMlgz6m0zxOcep4=";
+  useFetchCargoVendor = true;
 }


### PR DESCRIPTION
I kept getting errors like this in one of my flakebox projects, and this PR fixed it. I don't really understand why though lol.

```
error: hash mismatch in fixed-output derivation '/nix/store/mxqx5z826zpyadrwp67mfb6fwlaig3c6-flakebox-0.1.0-vendor.tar.gz.drv':
         specified: sha256-hsHGZAxZube9xpdVp4xxZu6c+9s0mLO1GpZlPIwJ348=
            got:    sha256-oDFRDC1dCraIoZhmcIlJ3EQ5OucKa0uSVttPxcoU3Sg=
```