### PR TITLE
fix: crane warning

### DIFF
--- a/checks/custom-stdenv/default.nix
+++ b/checks/custom-stdenv/default.nix
@@ -2,7 +2,7 @@
 let
 
   toolchainArgs = {
-    stdenv = pkgs.clang18Stdenv;
+    stdenv = p: p.clang18Stdenv;
     clang = pkgs.llvmPackages_18.clang;
     libclang = pkgs.llvmPackages_18.libclang.lib;
     clang-unwrapped = pkgs.llvmPackages_18.clang-unwrapped;

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -140,7 +140,7 @@ lib.makeScope pkgs.newScope (
         pkgs.llvmPackages.clang-unwrapped
       else
         pkgs.llvmPackages_18.clang-unwrapped;
-    defaultStdenv = if pkgs.stdenv.isDarwin then pkgs.llvmPackages_18.stdenv else pkgs.stdenv;
+    defaultStdenv = p: if pkgs.stdenv.isDarwin then pkgs.llvmPackages_18.stdenv else pkgs.stdenv;
 
     mkTarget = callPackage ./mkTarget.nix { };
     mkAndroidTarget = callPackage ./mkAndroidTarget.nix { };

--- a/lib/mkDevShell.nix
+++ b/lib/mkDevShell.nix
@@ -32,7 +32,12 @@ let
 in
 let
   mkShell =
-    if toolchain ? stdenv then pkgs.mkShell.override { stdenv = toolchain.stdenv; } else pkgs.mkShell;
+    if toolchain ? stdenv then
+      pkgs.mkShell.override {
+        stdenv = if lib.isFunction toolchain.stdenv then toolchain.stdenv pkgs else toolchain.stdenv;
+      }
+    else
+      pkgs.mkShell;
   flakeboxInit =
     if config.flakebox.init.enable then
       ''


### PR DESCRIPTION
```
mkCargoDerivation's stdenv argument was set to a specific stdenv instance
while an stdenv selector function is recommended. Consider specifying a
function which selects an stdenv for any given `pkgs` instantiation:

stdenv = p: p.stdenv;
```