### PR TITLE
fix: apply linker wrapping when stdenv is a function

### DIFF
--- a/lib/mkDevShell.nix
+++ b/lib/mkDevShell.nix
@@ -31,16 +31,15 @@ let
   ];
 in
 let
+  baseStdenv = if lib.isFunction toolchain.stdenv then toolchain.stdenv pkgs else pkgs.stdenv;
   mkShell = pkgs.mkShell.override {
     stdenv =
-      if lib.isFunction toolchain.stdenv then
-        toolchain.stdenv pkgs
-      else if pkgs.stdenv.isLinux && config.linker.wild.enable && pkgs ? useWildLinker then
-        pkgs.useWildLinker pkgs.stdenv
+      if pkgs.stdenv.isLinux && config.linker.wild.enable && pkgs ? useWildLinker then
+        pkgs.useWildLinker baseStdenv
       else if pkgs.stdenv.isLinux && config.linker.mold.enable && pkgs.stdenvAdapters ? useMoldLinker then
-        pkgs.stdenvAdapters.useMoldLinker pkgs.stdenv
+        pkgs.stdenvAdapters.useMoldLinker baseStdenv
       else
-        pkgs.stdenv;
+        baseStdenv;
   };
   flakeboxInit =
     if config.flakebox.init.enable then

--- a/lib/mkLintShell.nix
+++ b/lib/mkLintShell.nix
@@ -30,16 +30,15 @@ let
   ];
 in
 let
+  baseStdenv = if lib.isFunction toolchain.stdenv then toolchain.stdenv pkgs else pkgs.stdenv;
   mkShell = pkgs.mkShell.override {
     stdenv =
-      if lib.isFunction toolchain.stdenv then
-        toolchain.stdenv pkgs
-      else if pkgs.stdenv.isLinux && config.linker.wild.enable && pkgs ? useWildLinker then
-        pkgs.useWildLinker pkgs.stdenv
+      if pkgs.stdenv.isLinux && config.linker.wild.enable && pkgs ? useWildLinker then
+        pkgs.useWildLinker baseStdenv
       else if pkgs.stdenv.isLinux && config.linker.mold.enable && pkgs.stdenvAdapters ? useMoldLinker then
-        pkgs.stdenvAdapters.useMoldLinker pkgs.stdenv
+        pkgs.stdenvAdapters.useMoldLinker baseStdenv
       else
-        pkgs.stdenv;
+        baseStdenv;
   };
   args = cleanedArgs // {
     packages =


### PR DESCRIPTION
If stdenv is a function, we'll short-circuit and skip using linkers even if one is enabled.

For more context, see: https://github.com/fedimint/fedimint/issues/8146