### PR TITLE
Select debug compression by linker capability

### DIFF
--- a/checks/cross-linker-compression.nix
+++ b/checks/cross-linker-compression.nix
@@ -1,0 +1,70 @@
+{ pkgs, flakeboxLib }:
+let
+  target = "aarch64-unknown-linux-gnu";
+  targetPrefix = "aarch64-unknown-linux-gnu-";
+  toolchains = flakeboxLib.mkStdFenixToolchains { };
+  crossToolchain = toolchains.aarch64-linux;
+  args = flakeboxLib.mergeArgs toolchains.default.commonArgs crossToolchain.commonArgs;
+in
+pkgs.runCommand "aarch64-cross-linker-compression"
+  (
+    args
+    // {
+      nativeBuildInputs = (args.nativeBuildInputs or [ ]) ++ [ crossToolchain.toolchain ];
+    }
+  )
+  ''
+    export CARGO_HOME="$TMPDIR/cargo-home"
+    mkdir -p src
+
+    cat > Cargo.toml <<'EOF'
+    [package]
+    name = "cross-linker-compression-check"
+    version = "0.0.0"
+    edition = "2024"
+    EOF
+
+    cat > src/main.rs <<'EOF'
+    fn main() {
+        println!("cross-linker compression check");
+    }
+    EOF
+
+    cargo build --offline --target ${target}
+    cargo build --offline
+
+    linker_dir="$(dirname "$CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER")"
+    linker="$linker_dir/${targetPrefix}ld"
+    cross_binary="target/${target}/debug/cross-linker-compression-check"
+    native_binary="target/debug/cross-linker-compression-check"
+
+    "$linker" --version | grep -F "GNU ld"
+    case "$CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_RUSTFLAGS" in
+      *"-fuse-ld=$linker"*"--compress-debug-sections=zlib"*) ;;
+      *)
+        echo "AArch64 Rust flags do not select the tested linker and compression policy" >&2
+        exit 1
+        ;;
+    esac
+    "$linker" --compress-debug-sections=zlib --version >/dev/null
+    "$linker_dir/${targetPrefix}readelf" -h "$cross_binary" | grep -F "Machine:" | grep -F "AArch64"
+    "$linker_dir/${targetPrefix}readelf" -SW "$cross_binary" | grep -E '\.debug_info.* C '
+
+    native_linker="$(
+      printf '%s\n' "$CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS" \
+        | sed -n 's/.*--ld-path=\([^ ]*\).*/\1/p'
+    )"
+    case "$CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_RUSTFLAGS" in
+      *"--ld-path=$native_linker"*"--compress-debug-sections=zstd"*) ;;
+      *)
+        echo "native Rust flags do not preserve the Wild and zstd policy" >&2
+        exit 1
+        ;;
+    esac
+    "$native_linker" --version | grep -F "Wild"
+    "$native_linker" --compress-debug-sections=zstd --version >/dev/null
+    ${pkgs.binutils}/bin/readelf -h "$native_binary" | grep -F "Machine:" | grep -F "Advanced Micro Devices X86-64"
+    ${pkgs.binutils}/bin/readelf -SW "$native_binary" | grep -E '\.debug_info.* C '
+
+    touch "$out"
+  ''

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -24,5 +24,8 @@ onlyDrvs (
       cargoCrapModule = callPackage ./cargo-crap-module.nix { inherit mkLib; };
       gitHooks = callPackage ./git-hooks.nix { inherit mkLib; };
     }
+    // lib.optionalAttrs (pkgs.stdenv.buildPlatform.system == "x86_64-linux") {
+      crossLinkerCompression = callPackage ./cross-linker-compression.nix { };
+    }
   )
 )

--- a/docs/linux-toolchains.md
+++ b/docs/linux-toolchains.md
@@ -11,4 +11,8 @@ These toolchains use Nixpkgs cross-compilation packages, which
 are not guaranteed to be cached, so building them might take a
 long time. Binary cache is required to make it practical.
 
+Native Wild and mold linkers compress debug sections with zstd. For
+non-native targets, Flakebox instead asks Nixpkgs' target-specific GNU
+linker to use zlib, the strongest configured format it supports.
+
 These toolchains don't work on MacOS right now (unimplemented in Nixpkgs).

--- a/lib/mkClangTarget.nix
+++ b/lib/mkClangTarget.nix
@@ -12,6 +12,7 @@
   buildInputs ? [ ],
   nativeBuildInputs ? [ ],
   llvmConfigPkg ? clang,
+  compressDebugSections ? "zstd",
   args ? { },
   ...
 }@mkClangTargetArgs:
@@ -32,7 +33,7 @@ let
     "LD_${target_underscores}" = "${clang}/bin/${binPrefix}clang";
     "CARGO_TARGET_${target_underscores_upper}_LINKER" = "${clang}/bin/${binPrefix}clang";
     "CARGO_TARGET_${target_underscores_upper}_RUSTFLAGS" =
-      "-C link-arg=-fuse-ld=${clang}/bin/${binPrefix}ld -C link-arg=-Wl,--compress-debug-sections=zstd ${extraRustFlags}";
+      "-C link-arg=-fuse-ld=${clang}/bin/${binPrefix}ld -C link-arg=-Wl,--compress-debug-sections=${compressDebugSections} ${extraRustFlags}";
 
     inherit buildInputs nativeBuildInputs;
   } (mkClangTargetArgs.args or { });

--- a/lib/mkStdTargets.nix
+++ b/lib/mkStdTargets.nix
@@ -23,6 +23,7 @@
     target = "aarch64-unknown-linux-gnu";
     clang = pkgs.pkgsCross.aarch64-multiplatform.buildPackages.llvmPackages.clang;
     binPrefix = "aarch64-unknown-linux-gnu-";
+    compressDebugSections = "zlib";
     llvmConfigPkg = targetLlvmConfigWrapper {
       # seems like it would be better, but it seems to pull in incompatible glibc
       # clangPkg = pkgs.pkgsCross.aarch64-multiplatform.buildPackages.llvmPackages.clang;
@@ -44,6 +45,7 @@
     target = "x86_64-unknown-linux-gnu";
     clang = pkgs.pkgsCross.gnu64.buildPackages.llvmPackages.clang;
     binPrefix = "x86_64-unknown-linux-gnu-";
+    compressDebugSections = "zlib";
     llvmConfigPkg = targetLlvmConfigWrapper {
       # seems like it would be better, but it seems to pull in incompatible glibc
       # clangPkg = pkgs.pkgsCross.gnu32.buildPackages.llvmPackages.clang;
@@ -64,6 +66,7 @@
     target = "i686-unknown-linux-gnu";
     clang = pkgs.pkgsCross.gnu32.buildPackages.llvmPackages.clang;
     binPrefix = "i686-unknown-linux-gnu-";
+    compressDebugSections = "zlib";
     llvmConfigPkg = targetLlvmConfigWrapper {
       clangPkg = pkgs.pkgsCross.gnu32.buildPackages.llvmPackages.clang-unwrapped;
       libClangPkg = pkgs.pkgsCross.gnu32.buildPackages.llvmPackages.clang-unwrapped.lib;
@@ -81,6 +84,7 @@
     target = "riscv64gc-unknown-linux-gnu";
     clang = pkgs.pkgsCross.riscv64.buildPackages.llvmPackages.clang;
     binPrefix = "riscv64-unknown-linux-gnu-";
+    compressDebugSections = "zlib";
     llvmConfigPkg = targetLlvmConfigWrapper {
       clangPkg = pkgs.pkgsCross.riscv64.buildPackages.llvmPackages.clang-unwrapped;
       libClangPkg = pkgs.pkgsCross.riscv64.buildPackages.llvmPackages.clang-unwrapped.lib;


### PR DESCRIPTION
*Posted by Tau*

## Summary

Select compressed-debug formats according to each linker's declared capability. `mkClangTarget` keeps zstd as the default; only the four built-in Nixpkgs GNU/Linux cross targets explicitly use zlib because their target-prefixed `ld.bfd` builds reject zstd.

## Details

Native Wild and mold accept zstd and remain on zstd. Custom and future `mkClangTarget` users also retain zstd by default and may explicitly select another supported format. Native Darwin behavior is unchanged.

The built-in non-native Linux cells use Nixpkgs target-prefixed GNU `ld.bfd`. Direct AArch64, i686, and RISC-V probes report zstd unsupported and zlib supported. Nixpkgs exposes no stable compression-capability attribute, so those four target definitions declare their known zlib requirement instead of inferring support or globally lowering the policy.

Enabling zstd in those BFD linkers would require rebuilding cross binutils and rewrapping each cross Clang toolchain. This change avoids that dependency/cache expansion while preserving zstd everywhere the selected linker supports it.

The focused check performs two real Cargo links:

- native x86_64 through Wild with zstd;
- x86_64→AArch64 through GNU BFD with zlib.

It verifies the exact linker/flag combinations, option acceptance, ELF architecture, and compressed `.debug_info` in both outputs. The check is independent of PR #239.

Reviewers can validate the change with `nix develop -c selfci check --candidate sqzoqwsromon`.