### PR TITLE
feat(lint): dogfood ast-grep rules

### DIFF
--- a/.config/ast-grep/rule-tests/__snapshots__/is-err-then-unwrap-err-snapshot.yml
+++ b/.config/ast-grep/rule-tests/__snapshots__/is-err-then-unwrap-err-snapshot.yml
@@ -1,0 +1,22 @@
+id: is-err-then-unwrap-err
+snapshots:
+  ? |
+    if result.is_err() {
+        report(result.unwrap_err());
+    }
+  : labels:
+    - source: |-
+        if result.is_err() {
+            report(result.unwrap_err());
+        }
+      style: primary
+      start: 0
+      end: 55
+    - source: result.is_err()
+      style: secondary
+      start: 3
+      end: 18
+    - source: result.unwrap_err()
+      style: secondary
+      start: 32
+      end: 51

--- a/.config/ast-grep/rule-tests/__snapshots__/is-ok-then-unwrap-snapshot.yml
+++ b/.config/ast-grep/rule-tests/__snapshots__/is-ok-then-unwrap-snapshot.yml
@@ -1,0 +1,22 @@
+id: is-ok-then-unwrap
+snapshots:
+  ? |
+    if result.is_ok() {
+        consume(result.unwrap());
+    }
+  : labels:
+    - source: |-
+        if result.is_ok() {
+            consume(result.unwrap());
+        }
+      style: primary
+      start: 0
+      end: 51
+    - source: result.is_ok()
+      style: secondary
+      start: 3
+      end: 17
+    - source: result.unwrap()
+      style: secondary
+      start: 32
+      end: 47

--- a/.config/ast-grep/rule-tests/__snapshots__/is-some-then-unwrap-snapshot.yml
+++ b/.config/ast-grep/rule-tests/__snapshots__/is-some-then-unwrap-snapshot.yml
@@ -1,0 +1,22 @@
+id: is-some-then-unwrap
+snapshots:
+  ? |
+    if value.is_some() {
+        consume(value.unwrap());
+    }
+  : labels:
+    - source: |-
+        if value.is_some() {
+            consume(value.unwrap());
+        }
+      style: primary
+      start: 0
+      end: 51
+    - source: value.is_some()
+      style: secondary
+      start: 3
+      end: 18
+    - source: value.unwrap()
+      style: secondary
+      start: 33
+      end: 47

--- a/.config/ast-grep/rule-tests/__snapshots__/prefer-less-than-comparisons-snapshot.yml
+++ b/.config/ast-grep/rule-tests/__snapshots__/prefer-less-than-comparisons-snapshot.yml
@@ -1,0 +1,14 @@
+id: prefer-less-than-comparisons
+snapshots:
+  larger > smaller:
+    labels:
+    - source: larger > smaller
+      style: primary
+      start: 0
+      end: 16
+  larger >= smaller:
+    labels:
+    - source: larger >= smaller
+      style: primary
+      start: 0
+      end: 17

--- a/.config/ast-grep/rule-tests/__snapshots__/unwrap-in-production-snapshot.yml
+++ b/.config/ast-grep/rule-tests/__snapshots__/unwrap-in-production-snapshot.yml
@@ -1,0 +1,21 @@
+id: unwrap-in-production
+snapshots:
+  ? |
+    #[cfg(test)]
+    fn test_helper() {}
+
+    #[allow(dead_code)]
+    fn production() {
+        value.unwrap();
+    }
+  : labels:
+    - source: value.unwrap()
+      style: primary
+      start: 76
+      end: 90
+  value.unwrap():
+    labels:
+    - source: value.unwrap()
+      style: primary
+      start: 0
+      end: 14

--- a/.config/ast-grep/rule-tests/__snapshots__/unwrap-or-default-snapshot.yml
+++ b/.config/ast-grep/rule-tests/__snapshots__/unwrap-or-default-snapshot.yml
@@ -1,0 +1,14 @@
+id: unwrap-or-default
+snapshots:
+  value.unwrap_or(Default::default()):
+    labels:
+    - source: value.unwrap_or(Default::default())
+      style: primary
+      start: 0
+      end: 35
+  value.unwrap_or(String::default()):
+    labels:
+    - source: value.unwrap_or(String::default())
+      style: primary
+      start: 0
+      end: 34

--- a/.config/ast-grep/rule-tests/is-err-then-unwrap-err-test.yml
+++ b/.config/ast-grep/rule-tests/is-err-then-unwrap-err-test.yml
@@ -1,0 +1,15 @@
+id: is-err-then-unwrap-err
+valid:
+  - |
+    if let Err(error) = result {
+        report(error);
+    }
+  - |
+    if result.is_err() {
+        report(other.unwrap_err());
+    }
+invalid:
+  - |
+    if result.is_err() {
+        report(result.unwrap_err());
+    }

--- a/.config/ast-grep/rule-tests/is-ok-then-unwrap-test.yml
+++ b/.config/ast-grep/rule-tests/is-ok-then-unwrap-test.yml
@@ -1,0 +1,15 @@
+id: is-ok-then-unwrap
+valid:
+  - |
+    if let Ok(value) = result {
+        consume(value);
+    }
+  - |
+    if result.is_ok() {
+        consume(other.unwrap());
+    }
+invalid:
+  - |
+    if result.is_ok() {
+        consume(result.unwrap());
+    }

--- a/.config/ast-grep/rule-tests/is-some-then-unwrap-test.yml
+++ b/.config/ast-grep/rule-tests/is-some-then-unwrap-test.yml
@@ -1,0 +1,15 @@
+id: is-some-then-unwrap
+valid:
+  - |
+    if let Some(value) = value {
+        consume(value);
+    }
+  - |
+    if value.is_some() {
+        consume(other.unwrap());
+    }
+invalid:
+  - |
+    if value.is_some() {
+        consume(value.unwrap());
+    }

--- a/.config/ast-grep/rule-tests/prefer-less-than-comparisons-test.yml
+++ b/.config/ast-grep/rule-tests/prefer-less-than-comparisons-test.yml
@@ -1,0 +1,9 @@
+id: prefer-less-than-comparisons
+valid:
+  - smaller < larger
+  - smaller <= larger
+  - next_left() > next_right()
+  - object.left > object.right
+invalid:
+  - larger > smaller
+  - larger >= smaller

--- a/.config/ast-grep/rule-tests/unwrap-in-production-test.yml
+++ b/.config/ast-grep/rule-tests/unwrap-in-production-test.yml
@@ -1,0 +1,60 @@
+id: unwrap-in-production
+valid:
+  - value?
+  - value.expect("value was validated above")
+  - |
+    #[cfg(test)]
+    mod tests {
+        #[test]
+        fn works() {
+            value.unwrap();
+        }
+    }
+  - |
+    #[cfg(test)]
+    fn test_helper() {
+        value.unwrap();
+    }
+  - |
+    #[test]
+    fn works() {
+        value.unwrap();
+    }
+  - |
+    #[test]
+    #[should_panic]
+    fn panics() {
+        value.unwrap();
+    }
+  - |
+    #[cfg(test)]
+    #[allow(dead_code)]
+    fn test_helper() {
+        value.unwrap();
+    }
+  - |
+    #[cfg(test)]
+    #[allow(dead_code)]
+    mod tests {
+        fn helper() {
+            value.unwrap();
+        }
+    }
+  - |
+    #[cfg(test)]
+    #[allow(dead_code)]
+    impl Fixture {
+        fn helper() {
+            value.unwrap();
+        }
+    }
+invalid:
+  - value.unwrap()
+  - |
+    #[cfg(test)]
+    fn test_helper() {}
+
+    #[allow(dead_code)]
+    fn production() {
+        value.unwrap();
+    }

--- a/.config/ast-grep/rule-tests/unwrap-or-default-test.yml
+++ b/.config/ast-grep/rule-tests/unwrap-or-default-test.yml
@@ -1,0 +1,7 @@
+id: unwrap-or-default
+valid:
+  - value.unwrap_or_default()
+  - value.unwrap_or(fallback)
+invalid:
+  - value.unwrap_or(Default::default())
+  - value.unwrap_or(String::default())

--- a/.config/ast-grep/rules/is-err-then-unwrap-err.yml
+++ b/.config/ast-grep/rules/is-err-then-unwrap-err.yml
@@ -1,0 +1,14 @@
+id: is-err-then-unwrap-err
+language: Rust
+severity: warning
+message: Replace an is_err() check followed by unwrap_err() with if let Err(...).
+rule:
+  kind: if_expression
+  all:
+    - has:
+        field: condition
+        pattern: $VALUE.is_err()
+    - has:
+        field: consequence
+        stopBy: end
+        pattern: $VALUE.unwrap_err()

--- a/.config/ast-grep/rules/is-ok-then-unwrap.yml
+++ b/.config/ast-grep/rules/is-ok-then-unwrap.yml
@@ -1,0 +1,14 @@
+id: is-ok-then-unwrap
+language: Rust
+severity: warning
+message: Replace an is_ok() check followed by unwrap() with if let Ok(...).
+rule:
+  kind: if_expression
+  all:
+    - has:
+        field: condition
+        pattern: $VALUE.is_ok()
+    - has:
+        field: consequence
+        stopBy: end
+        pattern: $VALUE.unwrap()

--- a/.config/ast-grep/rules/is-some-then-unwrap.yml
+++ b/.config/ast-grep/rules/is-some-then-unwrap.yml
@@ -1,0 +1,14 @@
+id: is-some-then-unwrap
+language: Rust
+severity: warning
+message: Replace an is_some() check followed by unwrap() with if let Some(...).
+rule:
+  kind: if_expression
+  all:
+    - has:
+        field: condition
+        pattern: $VALUE.is_some()
+    - has:
+        field: consequence
+        stopBy: end
+        pattern: $VALUE.unwrap()

--- a/.config/ast-grep/rules/prefer-less-than-comparisons.yml
+++ b/.config/ast-grep/rules/prefer-less-than-comparisons.yml
@@ -1,0 +1,17 @@
+id: prefer-less-than-comparisons
+language: Rust
+severity: hint
+message: Put the lesser value on the left and use < or <= when comparing simple values.
+rule:
+  any:
+    - pattern: $LEFT > $RIGHT
+    - pattern: $LEFT >= $RIGHT
+constraints:
+  LEFT:
+    any:
+      - kind: identifier
+      - kind: integer_literal
+  RIGHT:
+    any:
+      - kind: identifier
+      - kind: integer_literal

--- a/.config/ast-grep/rules/unwrap-in-production.yml
+++ b/.config/ast-grep/rules/unwrap-in-production.yml
@@ -1,0 +1,40 @@
+id: unwrap-in-production
+language: Rust
+severity: warning
+message: Avoid unwrap() outside test code; propagate the error or document the invariant with expect().
+ignores:
+  - "**/benches/**"
+  - "**/examples/**"
+  - "**/tests/**"
+  - "**/tests.rs"
+  - "**/*-tests.rs"
+  - "**/*_test.rs"
+  - "**/*_tests.rs"
+  - "**/test_*.rs"
+rule:
+  all:
+    - pattern: $VALUE.unwrap()
+    - not:
+        inside:
+          stopBy: end
+          any:
+            - kind: mod_item
+              follows:
+                stopBy:
+                  not:
+                    kind: attribute_item
+                pattern: "#[cfg(test)]"
+            - kind: function_item
+              follows:
+                stopBy:
+                  not:
+                    kind: attribute_item
+                any:
+                  - pattern: "#[cfg(test)]"
+                  - pattern: "#[test]"
+            - kind: impl_item
+              follows:
+                stopBy:
+                  not:
+                    kind: attribute_item
+                pattern: "#[cfg(test)]"

--- a/.config/ast-grep/rules/unwrap-or-default.yml
+++ b/.config/ast-grep/rules/unwrap-or-default.yml
@@ -1,0 +1,8 @@
+id: unwrap-or-default
+language: Rust
+severity: warning
+message: Use unwrap_or_default() instead of constructing a default value eagerly.
+rule:
+  any:
+    - pattern: $VALUE.unwrap_or(Default::default())
+    - pattern: $VALUE.unwrap_or($TYPE::default())

--- a/checks/ast-grep-rules.nix
+++ b/checks/ast-grep-rules.nix
@@ -1,0 +1,45 @@
+{ pkgs }:
+pkgs.runCommand "ast-grep-rules"
+  {
+    nativeBuildInputs = [ pkgs.ast-grep ];
+    src = pkgs.lib.cleanSource ../.;
+  }
+  ''
+    cp -r "$src" source
+    chmod -R u+w source
+    cd source
+
+    # Promote the behavioral rules to CI errors while retaining the comparison
+    # orientation rule as an interactive style hint.
+    ast-grep scan --error --hint=prefer-less-than-comparisons
+    ast-grep test
+
+    mkdir -p \
+      ast-grep-fixtures/benches \
+      ast-grep-fixtures/examples \
+      ast-grep-fixtures/tests \
+      ast-grep-fixtures/src
+    for path in \
+      ast-grep-fixtures/benches/case.rs \
+      ast-grep-fixtures/examples/case.rs \
+      ast-grep-fixtures/tests/case.rs \
+      ast-grep-fixtures/src/check-tests.rs \
+      ast-grep-fixtures/src/check_test.rs \
+      ast-grep-fixtures/src/check_tests.rs \
+      ast-grep-fixtures/src/test_check.rs \
+      ast-grep-fixtures/src/tests.rs
+    do
+      printf 'fn fixture() { value.unwrap(); }\n' > "$path"
+      ast-grep scan --error "$path"
+    done
+
+    production_fixture=ast-grep-fixtures/src/check.rs
+    printf 'fn fixture() { value.unwrap(); }\n' > "$production_fixture"
+    if ast-grep scan --error "$production_fixture" > violation.log 2>&1; then
+      echo "production unwrap fixture unexpectedly passed" >&2
+      exit 1
+    fi
+    grep -Fq 'unwrap-in-production' violation.log
+
+    touch "$out"
+  ''

--- a/checks/cell-aware-cross-inputs/src/main.rs
+++ b/checks/cell-aware-cross-inputs/src/main.rs
@@ -1,5 +1,7 @@
 use openssl::ssl::{SslConnector, SslMethod};
 
 fn main() {
-    let _connector = SslConnector::builder(SslMethod::tls()).unwrap().build();
+    let _connector = SslConnector::builder(SslMethod::tls())
+        .expect("OpenSSL supports TLS")
+        .build();
 }

--- a/checks/default.nix
+++ b/checks/default.nix
@@ -24,6 +24,7 @@ onlyDrvs (
       craneMultiBuildTests = callPackage ./crane-multi-build-tests.nix { };
       cargoCrapModule = callPackage ./cargo-crap-module.nix { inherit mkLib; };
       astGrepModule = callPackage ./ast-grep-module.nix { inherit mkLib; };
+      astGrepRules = callPackage ./ast-grep-rules.nix { };
       gitHooks = callPackage ./git-hooks.nix { inherit mkLib; };
     }
     // lib.optionalAttrs (pkgs.stdenv.buildPlatform.system == "x86_64-linux") {

--- a/lib/pkgs/git-hook-check-timer.rs
+++ b/lib/pkgs/git-hook-check-timer.rs
@@ -72,7 +72,7 @@ impl ChildSignalState {
             if current_state == SHUTTING_DOWN {
                 return None;
             }
-            if current_state > 0 {
+            if 0 < current_state {
                 return Some(current_state);
             }
 

--- a/sgconfig.yml
+++ b/sgconfig.yml
@@ -1,0 +1,5 @@
+ruleDirs:
+  - .config/ast-grep/rules
+
+testConfigs:
+  - testDir: .config/ast-grep/rule-tests


### PR DESCRIPTION
*Posted by Tau*

## Summary

Adopt the newly integrated ast-grep workflow in Flakebox itself with six conservative Rust rules, focused rule tests, and CI enforcement. Keep the rule implementation under `.config/ast-grep/` while preserving standard root project discovery through `sgconfig.yml`.

## Details

- discourage production `unwrap()` while exempting conventional and structurally annotated test code
- catch `is_some`/`is_ok`/`is_err` checks followed by corresponding unwrap calls
- catch eager default construction passed to `unwrap_or`
- hint on greater-than orientation only for side-effect-free identifier/integer comparisons
- commit valid/invalid cases and diagnostic snapshots for every rule
- add a flake check that runs tests, promotes behavioral findings to errors, and behaviorally verifies pathname exclusions

## Testing

Run `selfci check`. For focused iteration, run `ast-grep test` and `ast-grep scan`.